### PR TITLE
Changing GTM script location

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
 # ReciteMe-TagMan
 GogoleTag-Manager Plugin for ReciteMe
+
 # reciteme-tagmanager

--- a/template.tpl
+++ b/template.tpl
@@ -64,7 +64,7 @@ if (!data.optionsJson) {
 const queryPermission = require('queryPermission');
 const injectScript = require('injectScript');
 const setInWindow = require('setInWindow');
-const scriptUrl = 'https://reciteme.com/gtm-script.js';
+const scriptUrl = 'https://gtm.reciteme.com/gtm-script.js';
 const JSON = require('JSON');
 
 if (!queryPermission('access_globals', 'readwrite', 'serviceKey')) {
@@ -136,7 +136,7 @@ ___WEB_PERMISSIONS___
             "listItem": [
               {
                 "type": 1,
-                "string": "https://reciteme.com/gtm-script.js"
+                "string": "https://gtm.reciteme.com/gtm-script.js"
               }
             ]
           }


### PR DESCRIPTION
Hey @recite-me-richard could you give this the once over for me and specifically check that i have included the location change of the gtm-script.js in all necessary places.  The main change here is that we're moving from https://reciteme.com/gtm-script.js to https://gtm.reciteme.com/gtm-script.js

Please could you also check https://gtm.reciteme.com/gtm-script.js and let me know if you foresee any issues.

I have tested this by importing the template.tpl file into GTM as a new local template and tested it on a local page.  This seems to work fine from my side.  Again, can you foresee any problems with this?

Once we're all happy i believe that the last thing to do will be to tag the latest release in the metatdata.yaml file to point to the latest commit.  Please don't make that change as of yet as i will need to circulate some information about the update first.